### PR TITLE
fix a cli problem

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -9,8 +9,9 @@ var vm = require("vm");
 var traceur = require("traceur");
 var transfer = require("multi-stage-sourcemap").transfer;
 var spider = require("./lib/spider");
+var nomnom = require("nomnom");
 
-var opts = require("nomnom")
+var opts = nomnom
   .option("files", {
     position: 0,
     help: "files to compile",
@@ -80,6 +81,11 @@ if (opts.target === "ES5") {
     sourceMaps: true,
     asyncFunctions: true
   });
+}
+
+if (!opts.files) {
+  console.log(nomnom.getUsage());
+  process.exit(0);
 }
 
 opts.files.forEach(function (fileName, fileIndex) {


### PR DESCRIPTION
if i use the cli "spider" without any parameter, the cli.js would throw an error says "opts.files is undefined". I think if I do this, the cli should return a help message, so i add a if statement to find whether opts.files is undefined, if it is, console a help message and exit.  
I think this is a better way than throw an error directly :-)  
PS.spider-lang is cool and really want submit more pr : p
