### PR TITLE
Added modules option and .spider extension importing

### DIFF
--- a/lib/spider.js
+++ b/lib/spider.js
@@ -45,6 +45,7 @@ $traceurRuntime.ModuleStore.getAnonymousModule(function() {
     if (options.target === "ES5") {
       var traceurCompiler = new traceur.NodeCompiler({
         sourceMaps: options.generateSourceMap,
+        modules: options.modules,
         asyncFunctions: true
       });
       result.result = traceurCompiler.compile(result.result, options.fileName, outFileName);

--- a/src/spider.spider
+++ b/src/spider.spider
@@ -73,6 +73,7 @@ exports.compile = fn (options) {
   if options.target == "ES5" {
     var traceurCompiler = new traceur.NodeCompiler({
       sourceMaps: options.generateSourceMap,
+      modules: options.modules,
       asyncFunctions: true
     });
     


### PR DESCRIPTION
For importing, this is the best I could do:

``` js
import * as mod from 'mod'; // Spider module
import 'mod2' as mod2;      // Node.js module
```
