### PR TITLE
Fixed iifi body-less compiling

### DIFF
--- a/lib/spider.js
+++ b/lib/spider.js
@@ -183,6 +183,8 @@ $traceurRuntime.ModuleStore.getAnonymousModule(function() {
             "arguments": []
           }
         });
+      } else {
+        body = body.concat(tree.body);
       }
       tree = {
         "type": "Program",

--- a/src/spider.spider
+++ b/src/spider.spider
@@ -237,6 +237,8 @@ fn wrapCode(tree, useStrict = false, iifi = false) {
           "arguments": []
         }
       });
+    } else {
+      body = body.concat(tree.body);
     }
       
     tree = {


### PR DESCRIPTION
When compiling to ES6 with `iifi: false`, the `wrapCode` function skips the body! This should fix it.
